### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Crypto Tools [![Build Status](https://api.travis-ci.com/apache/fineract-cn-crypto.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-crypto)
+# Apache Fineract CN Crypto Tools
 
 ## Abstract
 Utility component to create random salts and hash credentials.


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.